### PR TITLE
修复local模式下,mic构造模式缺少参数以及模拟的函数

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/client/local_mic.py
+++ b/client/local_mic.py
@@ -9,7 +9,7 @@ implementation, Dingdang is always active listening with local_mic.
 class Mic:
     prev = None
 
-    def __init__(self, speaker, passive_stt_engine, active_stt_engine):
+    def __init__(self, config, speaker, passive_stt_engine, active_stt_engine):
         return
 
     def passiveListen(self, PERSONA):
@@ -30,3 +30,6 @@ class Mic:
 
     def say(self, phrase, OPTIONS=None):
         print("DINGDANG: %s" % phrase)
+
+    def stop_passive(self):
+        pass


### PR DESCRIPTION
修复local模式下,mic构造模式缺少参数以及模拟的函数，添加了一个模拟的构造函数和模拟的方法