### PR TITLE
增加讯飞的语音识别和合成模块，增加阿里的语音识别模块

### DIFF
--- a/client/stt.py
+++ b/client/stt.py
@@ -18,7 +18,6 @@ import time
 import hashlib
 import datetime
 import hmac
-import urllib2
 
 import sys
 
@@ -304,6 +303,7 @@ class BaiduSTT(AbstractSTTEngine):
     @classmethod
     def is_available(cls):
         return diagnose.check_network_connection()
+
     
 class IFlyTekSTT(AbstractSTTEngine):
     """
@@ -320,6 +320,7 @@ class IFlyTekSTT(AbstractSTTEngine):
         self._logger = logging.getLogger(__name__)
         self.api_id = api_id
         self.api_key = api_key
+        
     @classmethod
     def get_config(cls):
         # FIXME: Replace this as soon as we have a config module
@@ -353,14 +354,16 @@ class IFlyTekSTT(AbstractSTTEngine):
         base_data = base64.b64encode(audio)
         data = {'data': base_data}
         m = hashlib.md5()
-        m.update(self.api_key + str(int(time.time())) + XParam + 'data=' + base_data)
+        m.update(self.api_key + str(int(time.time())) + \
+                 XParam + 'data=' + base_data)
         checksum = m.hexdigest()
 
-        headers = {'X-Appid':self.api_id,
-                'X-CurTime':str(int(time.time())),
-                'X-Param':XParam,
-                'X-CheckSum':checksum}
-
+        headers = {
+            'X-Appid': self.api_id,
+            'X-CurTime': str(int(time.time())),
+            'X-Param': Param,
+            'X-CheckSum': checksum
+        }
         r = requests.post('http://api.xfyun.cn/v1/aiui/v1/iat',
                           data=data,
                           headers=headers)
@@ -412,7 +415,6 @@ class ALiBaBaSTT(AbstractSTTEngine):
         self.ak_id = ak_id
         self.ak_secret = ak_secret
 
-
     @classmethod
     def get_config(cls):
         # FIXME: Replace this as soon as we have a config module
@@ -431,7 +433,7 @@ class ALiBaBaSTT(AbstractSTTEngine):
                             profile['ali_yuyin']['ak_secret']
         return config
 
-    def to_md5_base64(self,strBody):
+    def to_md5_base64(self, strBody):
         hash = hashlib.md5()
         hash.update(self.body)
         m = hash.digest().encode('base64').strip()
@@ -439,7 +441,7 @@ class ALiBaBaSTT(AbstractSTTEngine):
         hash.update(m)
         return hash.digest().encode('base64').strip()
 
-    def to_sha1_base64(self,stringToSign, secret):
+    def to_sha1_base64(self, stringToSign, secret):
         hmacsha1 = hmac.new(secret, stringToSign, hashlib.sha1)
         return base64.b64encode(hmacsha1.digest())
 
@@ -453,7 +455,8 @@ class ALiBaBaSTT(AbstractSTTEngine):
             return []
         n_frames = wav_file.getnframes()
         audio = wav_file.readframes(n_frames)
-        date = datetime.datetime.strftime(datetime.datetime.utcnow(), "%a, %d %b %Y %H:%M:%S GMT")
+        date = datetime.datetime.strftime(datetime.datetime.utcnow(), \
+                                          "%a, %d %b %Y %H:%M:%S GMT")
         options = {
             'url': 'https://nlsapi.aliyun.com/recognize?model=chat',
             'method': 'POST',
@@ -475,7 +478,8 @@ class ALiBaBaSTT(AbstractSTTEngine):
         if not self.body == '':
             bodymd5 = self.to_md5_base64(self.body)
 
-        stringToSign = options['method'] + '\n' + headers['accept'] + '\n' + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
+        stringToSign = options['method'] + '\n' + headers['accept'] + '\n' + bodymd5 \
+        + '\n' + headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/stt.py
+++ b/client/stt.py
@@ -299,6 +299,222 @@ class BaiduSTT(AbstractSTTEngine):
     @classmethod
     def is_available(cls):
         return diagnose.check_network_connection()
+    
+class IFLYTEAKSTT(AbstractSTTEngine):
+    """
+    科大讯飞的语音识别API.
+    要使用本模块, 首先到 http://aiui.xfyun.cn/default/index 注册一个开发者账号,
+    之后创建一个新应用, 然后在应用管理的那查看 API id 和 API Key
+    填入 profile.xml 中.
+.
+    """
+
+    SLUG = "iflytek-stt"
+
+    def __init__(self, api_id, api_key):
+        self._logger = logging.getLogger(__name__)
+        self.api_id = api_id
+        self.api_key = api_key
+
+
+    @classmethod
+    def get_config(cls):
+        # FIXME: Replace this as soon as we have a config module
+        config = {}
+        # Try to get iflytek_yuyin config from config
+        profile_path = dingdangpath.config('profile.yml')
+        if os.path.exists(profile_path):
+            with open(profile_path, 'r') as f:
+                profile = yaml.safe_load(f)
+                if 'iflytek_yuyin' in profile:
+                    if 'api_id' in profile['iflytek_yuyin']:
+                        config['api_id'] = \
+                            profile['iflytek_yuyin']['api_id']
+                    if 'api_key' in profile['iflytek_yuyin']:
+                        config['api_key'] = \
+                            profile['iflytek_yuyin']['api_key']
+        return config
+
+    def transcribe(self, fp):
+        try:
+            wav_file = wave.open(fp, 'rb')
+        except IOError:
+            self._logger.critical('wav file not found: %s',
+                                  fp,
+                                  exc_info=True)
+            return []
+        Param = '{"auf":"16k","aue":"raw","scene":"main"}'
+        XParam = base64.b64encode(Param)
+        n_frames = wav_file.getnframes()
+        frame_rate = wav_file.getframerate()
+        audio = wav_file.readframes(n_frames)
+        base_data = base64.b64encode(audio)
+        data = {'data': base_data}
+        m = hashlib.md5()
+        m.update(self.api_key + str(int(time.time())) + XParam + 'data=' + base_data)
+        checksum = m.hexdigest()
+
+        headers = {'X-Appid':self.api_id,
+                'X-CurTime':str(int(time.time())),
+                'X-Param':XParam,
+                'X-CheckSum':checksum}
+
+        r = requests.post('http://api.xfyun.cn/v1/aiui/v1/iat',
+                          data=data,
+                          headers=headers)
+        try:
+            r.raise_for_status()
+            text = ''
+            if r.json()['code'] == '00000':
+                text = r.json()['data']['result'].encode('utf-8')
+        except requests.exceptions.HTTPError:
+            self._logger.critical('Request failed with response: %r',
+                                  r.text,
+                                  exc_info=True)
+            return []
+        except requests.exceptions.RequestException:
+            self._logger.critical('Request failed.', exc_info=True)
+            return []
+        except ValueError as e:
+            self._logger.critical('Cannot parse response: %s',
+                                  e.args[0])
+            return []
+        except KeyError:
+            self._logger.critical('Cannot parse response.',
+                                  exc_info=True)
+            return []
+        else:
+            transcribed = []
+            if text:
+                transcribed.append(text.upper())
+            self._logger.info(u'讯飞语音识别到了: %s' % text)
+            return transcribed
+
+    @classmethod
+    def is_available(cls):
+        return diagnose.check_network_connection()
+
+
+class ALIBABASTT(AbstractSTTEngine):
+    """
+    阿里云的语音识别API.
+    要使用本模块, 首先到 https://data.aliyun.com/product/nls 注册一个开发者账号,
+    然后查看自己的AK信息，填入 profile.xml 中.
+.
+    """
+
+    SLUG = "ali-stt"
+
+    def __init__(self, ak_id, ak_secret):
+        self._logger = logging.getLogger(__name__)
+        self.ak_id = ak_id
+        self.ak_secret = ak_secret
+
+
+    @classmethod
+    def get_config(cls):
+        # FIXME: Replace this as soon as we have a config module
+        config = {}
+        # Try to get iflytek_yuyin config from config
+        profile_path = dingdangpath.config('profile.yml')
+        if os.path.exists(profile_path):
+            with open(profile_path, 'r') as f:
+                profile = yaml.safe_load(f)
+                if 'ali_yuyin' in profile:
+                    if 'ak_id' in profile['ali_yuyin']:
+                        config['ak_id'] = \
+                            profile['ali_yuyin']['ak_id']
+                    if 'ak_secret' in profile['ali_yuyin']:
+                        config['ak_secret'] = \
+                            profile['ali_yuyin']['ak_secret']
+        return config
+
+    def to_md5_base64(self,strBody):
+        hash = hashlib.md5()
+        hash.update(self.body)
+        m = hash.digest().encode('base64').strip()
+        hash = hashlib.md5()
+        hash.update(m)
+        return hash.digest().encode('base64').strip()
+
+    def to_sha1_base64(self,stringToSign, secret):
+        hmacsha1 = hmac.new(secret, stringToSign, hashlib.sha1)
+        return base64.b64encode(hmacsha1.digest())
+
+    def transcribe(self, fp):
+        try:
+            wav_file = wave.open(fp, 'rb')
+        except IOError:
+            self._logger.critical('wav file not found: %s',
+                                  fp,
+                                  exc_info=True)
+            return []
+        n_frames = wav_file.getnframes()
+        frame_rate = wav_file.getframerate()
+        audio = wav_file.readframes(n_frames)
+        date = datetime.datetime.strftime(datetime.datetime.utcnow(), "%a, %d %b %Y %H:%M:%S GMT")
+        options = {
+            'url': 'https://nlsapi.aliyun.com/recognize?model=chat',
+            'method': 'POST',
+            'body': audio,
+        }
+        headers = {
+            'authorization': '',
+            'content-type': 'audio/wav; samplerate=16000',
+            'accept': 'application/json',
+            'date': date,
+            'Content-Length': str(len(audio))
+        }
+
+        self.body = ''
+        if 'body' in options:
+            self.body = options['body']
+
+        bodymd5 = ''
+        if not self.body == '':
+            bodymd5 = self.to_md5_base64(self.body)
+
+        stringToSign = options['method'] + '\n' + headers['accept'] + '\n' + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
+        signature = self.to_sha1_base64(stringToSign, self.ak_secret)
+
+        authHeader = 'Dataplus ' + self.ak_id + ':' + signature
+        headers['authorization'] = authHeader
+
+        request = None
+        method = options['method']
+        url = options['url']
+
+        r = requests.post(url, data=self.body, headers=headers, verify=False)
+        try:
+            text = ''
+            if 'result' in r.json():
+                text = r.json()['result'].encode('utf-8')
+        except requests.exceptions.HTTPError:
+            self._logger.critical('Request failed with response: %r',
+                                  r.text,
+                                  exc_info=True)
+            return []
+        except requests.exceptions.RequestException:
+            self._logger.critical('Request failed.', exc_info=True)
+            return []
+        except ValueError as e:
+            self._logger.critical('Cannot parse response: %s',
+                                  e.args[0])
+            return []
+        except KeyError:
+            self._logger.critical('Cannot parse response.',
+                                  exc_info=True)
+            return []
+        else:
+            transcribed = []
+            if text:
+                transcribed.append(text.upper())
+            self._logger.info(u'阿里云语音识别到了: %s' % text)
+            return transcribed
+
+    @classmethod
+    def is_available(cls):
+        return diagnose.check_network_connection()
 
 
 class SnowboySTT(AbstractSTTEngine):

--- a/client/stt.py
+++ b/client/stt.py
@@ -479,8 +479,8 @@ class ALiBaBaSTT(AbstractSTTEngine):
             bodymd5 = self.to_md5_base64(self.body)
 
         stringToSign = options['method'] + '\n' + \
-                       headers['accept'] + '\n' + bodymd5 + '\n' + \
-                       headers['content-type'] + '\n' + headers['date']
+            headers['accept'] + '\n' + bodymd5 + '\n' + \
+            headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/stt.py
+++ b/client/stt.py
@@ -304,7 +304,7 @@ class BaiduSTT(AbstractSTTEngine):
     def is_available(cls):
         return diagnose.check_network_connection()
 
-    
+
 class IFlyTekSTT(AbstractSTTEngine):
     """
     科大讯飞的语音识别API.
@@ -320,7 +320,7 @@ class IFlyTekSTT(AbstractSTTEngine):
         self._logger = logging.getLogger(__name__)
         self.api_id = api_id
         self.api_key = api_key
-        
+
     @classmethod
     def get_config(cls):
         # FIXME: Replace this as soon as we have a config module
@@ -354,8 +354,8 @@ class IFlyTekSTT(AbstractSTTEngine):
         base_data = base64.b64encode(audio)
         data = {'data': base_data}
         m = hashlib.md5()
-        m.update(self.api_key + str(int(time.time())) + \
-                 XParam + 'data=' + base_data)
+        m.update(self.api_key + str(int(time.time())) 
+                 + XParam + 'data=' + base_data)
         checksum = m.hexdigest()
 
         headers = {
@@ -455,7 +455,7 @@ class ALiBaBaSTT(AbstractSTTEngine):
             return []
         n_frames = wav_file.getnframes()
         audio = wav_file.readframes(n_frames)
-        date = datetime.datetime.strftime(datetime.datetime.utcnow(), \
+        date = datetime.datetime.strftime(datetime.datetime.utcnow(), 
                                           "%a, %d %b %Y %H:%M:%S GMT")
         options = {
             'url': 'https://nlsapi.aliyun.com/recognize?model=chat',
@@ -478,8 +478,8 @@ class ALiBaBaSTT(AbstractSTTEngine):
         if not self.body == '':
             bodymd5 = self.to_md5_base64(self.body)
 
-        stringToSign = options['method'] + '\n' + headers['accept'] + '\n' + bodymd5 \
-        + '\n' + headers['content-type'] + '\n' + headers['date']
+        stringToSign = options['method'] + '\n' + headers['accept'] + '\n'\
+        + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/stt.py
+++ b/client/stt.py
@@ -197,8 +197,7 @@ class BaiduSTT(AbstractSTTEngine):
     要使用本模块, 首先到 yuyin.baidu.com 注册一个开发者账号,
     之后创建一个新应用, 然后在应用管理的"查看key"中获得 API Key 和 Secret Key
     填入 profile.xml 中.
-
-        ...
+    ...
         baidu_yuyin: 'AIzaSyDoHmTEToZUQrltmORWS4Ott0OHVA62tw8'
             api_key: 'LMFYhLdXSSthxCNLR7uxFszQ'
             secret_key: '14dbd10057xu7b256e537455698c0e4e'
@@ -311,7 +310,6 @@ class IFlyTekSTT(AbstractSTTEngine):
     要使用本模块, 首先到 http://aiui.xfyun.cn/default/index 注册一个开发者账号,
     之后创建一个新应用, 然后在应用管理的那查看 API id 和 API Key
     填入 profile.xml 中.
-.
     """
 
     SLUG = "iflytek-stt"
@@ -405,7 +403,6 @@ class ALiBaBaSTT(AbstractSTTEngine):
     阿里云的语音识别API.
     要使用本模块, 首先到 https://data.aliyun.com/product/nls 注册一个开发者账号,
     然后查看自己的AK信息，填入 profile.xml 中.
-.
     """
 
     SLUG = "ali-stt"

--- a/client/stt.py
+++ b/client/stt.py
@@ -14,6 +14,11 @@ import dingdangpath
 import diagnose
 import vocabcompiler
 from uuid import getnode as get_mac
+import time
+import hashlib
+import datetime
+import hmac
+import urllib2
 
 import sys
 

--- a/client/stt.py
+++ b/client/stt.py
@@ -479,8 +479,8 @@ class ALiBaBaSTT(AbstractSTTEngine):
             bodymd5 = self.to_md5_base64(self.body)
 
         stringToSign = options['method'] + '\n' + \
-        headers['accept'] + '\n' + bodymd5 + '\n' + \
-        headers['content-type'] + '\n' + headers['date']
+                       headers['accept'] + '\n' + bodymd5 + '\n' + \
+                       headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/stt.py
+++ b/client/stt.py
@@ -320,8 +320,6 @@ class IFLYTEAKSTT(AbstractSTTEngine):
         self._logger = logging.getLogger(__name__)
         self.api_id = api_id
         self.api_key = api_key
-
-
     @classmethod
     def get_config(cls):
         # FIXME: Replace this as soon as we have a config module
@@ -351,7 +349,6 @@ class IFLYTEAKSTT(AbstractSTTEngine):
         Param = '{"auf":"16k","aue":"raw","scene":"main"}'
         XParam = base64.b64encode(Param)
         n_frames = wav_file.getnframes()
-        frame_rate = wav_file.getframerate()
         audio = wav_file.readframes(n_frames)
         base_data = base64.b64encode(audio)
         data = {'data': base_data}
@@ -455,7 +452,6 @@ class ALIBABASTT(AbstractSTTEngine):
                                   exc_info=True)
             return []
         n_frames = wav_file.getnframes()
-        frame_rate = wav_file.getframerate()
         audio = wav_file.readframes(n_frames)
         date = datetime.datetime.strftime(datetime.datetime.utcnow(), "%a, %d %b %Y %H:%M:%S GMT")
         options = {
@@ -484,11 +480,7 @@ class ALIBABASTT(AbstractSTTEngine):
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature
         headers['authorization'] = authHeader
-
-        request = None
-        method = options['method']
         url = options['url']
-
         r = requests.post(url, data=self.body, headers=headers, verify=False)
         try:
             text = ''

--- a/client/stt.py
+++ b/client/stt.py
@@ -478,8 +478,9 @@ class ALiBaBaSTT(AbstractSTTEngine):
         if not self.body == '':
             bodymd5 = self.to_md5_base64(self.body)
 
-        stringToSign = options['method'] + '\n' + headers['accept'] + '\n'\
-                       + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
+        stringToSign = options['method'] + '\n' + \
+        headers['accept'] + '\n' + bodymd5 + '\n' + \
+        headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/stt.py
+++ b/client/stt.py
@@ -305,7 +305,7 @@ class BaiduSTT(AbstractSTTEngine):
     def is_available(cls):
         return diagnose.check_network_connection()
     
-class IFLYTEAKSTT(AbstractSTTEngine):
+class IFlyTekSTT(AbstractSTTEngine):
     """
     科大讯飞的语音识别API.
     要使用本模块, 首先到 http://aiui.xfyun.cn/default/index 注册一个开发者账号,
@@ -397,7 +397,7 @@ class IFLYTEAKSTT(AbstractSTTEngine):
         return diagnose.check_network_connection()
 
 
-class ALIBABASTT(AbstractSTTEngine):
+class ALiBaBaSTT(AbstractSTTEngine):
     """
     阿里云的语音识别API.
     要使用本模块, 首先到 https://data.aliyun.com/product/nls 注册一个开发者账号,

--- a/client/stt.py
+++ b/client/stt.py
@@ -354,7 +354,7 @@ class IFlyTekSTT(AbstractSTTEngine):
         base_data = base64.b64encode(audio)
         data = {'data': base_data}
         m = hashlib.md5()
-        m.update(self.api_key + str(int(time.time())) 
+        m.update(self.api_key + str(int(time.time()))
                  + XParam + 'data=' + base_data)
         checksum = m.hexdigest()
 
@@ -455,7 +455,7 @@ class ALiBaBaSTT(AbstractSTTEngine):
             return []
         n_frames = wav_file.getnframes()
         audio = wav_file.readframes(n_frames)
-        date = datetime.datetime.strftime(datetime.datetime.utcnow(), 
+        date = datetime.datetime.strftime(datetime.datetime.utcnow(),
                                           "%a, %d %b %Y %H:%M:%S GMT")
         options = {
             'url': 'https://nlsapi.aliyun.com/recognize?model=chat',
@@ -479,7 +479,7 @@ class ALiBaBaSTT(AbstractSTTEngine):
             bodymd5 = self.to_md5_base64(self.body)
 
         stringToSign = options['method'] + '\n' + headers['accept'] + '\n'\
-        + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
+                       + bodymd5 + '\n' + headers['content-type'] + '\n' + headers['date']
         signature = self.to_sha1_base64(stringToSign, self.ak_secret)
 
         authHeader = 'Dataplus ' + self.ak_id + ':' + signature

--- a/client/tts.py
+++ b/client/tts.py
@@ -18,11 +18,6 @@ import urllib
 import requests
 from abc import ABCMeta, abstractmethod
 from uuid import getnode as get_mac
-import datetime
-import base64
-import hmac
-import hashlib
-import json
 
 import argparse
 import yaml

--- a/client/tts.py
+++ b/client/tts.py
@@ -517,6 +517,71 @@ class BaiduTTS(AbstractMp3TTSEngine):
         if tmpfile is not None:
             self.play_mp3(tmpfile)
             os.remove(tmpfile)
+            
+ 
+class IFlyTekTTS(AbstractMp3TTSEngine):
+    """
+    使用讯飞的语音合成技术
+
+    要使用本模块, 请先在 profile.xml 中启用本模块并选择合适的发音人.
+
+    """
+
+    SLUG = "iflytek-tts"
+
+    def __init__(self, vid='60170'):
+        self._logger = logging.getLogger(__name__)
+        self.vid = vid
+
+    @classmethod
+    def get_config(cls):
+        # FIXME: Replace this as soon as we have a config module
+        config = {}
+        # Try to get baidu_yuyin config from config
+        profile_path = dingdangpath.config('profile.yml')
+        if os.path.exists(profile_path):
+            with open(profile_path, 'r') as f:
+                profile = yaml.safe_load(f)
+                if 'iflytek_yuyin' in profile:
+                    if 'vid' in profile['iflytek_yuyin']:
+                        config['vid'] = \
+                            profile['iflytek_yuyin']['vid']
+        return config
+
+    @classmethod
+    def is_available(cls):
+        return diagnose.check_network_connection()
+
+
+    def split_sentences(self, text):
+        punctuations = ['.', '。', ';', '；', '\n']
+        for i in punctuations:
+            text = text.replace(i, '@@@')
+        return text.split('@@@')
+
+    def get_speech(self, phrase):
+        getinfo_url = 'http://www.peiyinge.com/make/getSynthSign'
+        voice_baseurl = 'http://proxy.peiyinge.com:17063/synth?ts='
+        data = {
+            'content': phrase.encode('utf8')
+        }
+        result_info = requests.post(getinfo_url, data=data).json()
+        content = urllib.quote(phrase.encode('utf8'))
+        ts = result_info['ts']
+        sign = result_info['sign']
+        voice_url = voice_baseurl + ts + '&sign=' + sign + '&vid=' + self.vid + '&volume=&speed=0&content=' + content
+        r = requests.get(voice_url)
+        with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
+            f.write(r.content)
+            tmpfile = f.name
+            return tmpfile
+
+    def say(self, phrase):
+        self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
+        tmpfile = self.get_speech(phrase)
+        if tmpfile is not None:
+            self.play_mp3(tmpfile)
+            os.remove(tmpfile)
 
 
 def get_default_engine_slug():

--- a/client/tts.py
+++ b/client/tts.py
@@ -568,7 +568,7 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
         ts = result_info['ts']
         sign = result_info['sign']
         voice_url = voice_baseurl + ts + '&sign=' + sign + \
-                    '&vid=' + self.vid + '&volume=&speed=0&content=' + content
+            '&vid=' + self.vid + '&volume=&speed=0&content=' + content
         r = requests.get(voice_url)
         with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
             f.write(r.content)

--- a/client/tts.py
+++ b/client/tts.py
@@ -18,6 +18,11 @@ import urllib
 import requests
 from abc import ABCMeta, abstractmethod
 from uuid import getnode as get_mac
+import datetime
+import base64
+import hmac
+import hashlib
+import json
 
 import argparse
 import yaml

--- a/client/tts.py
+++ b/client/tts.py
@@ -517,10 +517,11 @@ class BaiduTTS(AbstractMp3TTSEngine):
         if tmpfile is not None:
             self.play_mp3(tmpfile)
             os.remove(tmpfile)
+
+
 class IFlyTekTTS(AbstractMp3TTSEngine):
     """
     使用讯飞的语音合成技术
-
     要使用本模块, 请先在 profile.xml 中启用本模块并选择合适的发音人.
 
     """
@@ -550,7 +551,6 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
     def is_available(cls):
         return diagnose.check_network_connection()
 
-
     def split_sentences(self, text):
         punctuations = ['.', '。', ';', '；', '\n']
         for i in punctuations:
@@ -567,7 +567,8 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
         content = urllib.quote(phrase.encode('utf8'))
         ts = result_info['ts']
         sign = result_info['sign']
-        voice_url = voice_baseurl + ts + '&sign=' + sign + '&vid=' + self.vid + '&volume=&speed=0&content=' + content
+        voice_url = voice_baseurl + ts + '&sign=' + sign + \
+                    '&vid=' + self.vid + '&volume=&speed=0&content=' + content
         r = requests.get(voice_url)
         with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
             f.write(r.content)

--- a/client/tts.py
+++ b/client/tts.py
@@ -416,12 +416,10 @@ class PicoTTS(AbstractTTSEngine):
 class BaiduTTS(AbstractMp3TTSEngine):
     """
     使用百度语音合成技术
-
     要使用本模块, 首先到 yuyin.baidu.com 注册一个开发者账号,
     之后创建一个新应用, 然后在应用管理的"查看key"中获得 API Key 和 Secret Key
     填入 profile.xml 中.
-
-        ...
+    ...
         baidu_yuyin: 'AIzaSyDoHmTEToZUQrltmORWS4Ott0OHVA62tw8'
             api_key: 'LMFYhLdXSSthxCNLR7uxFszQ'
             secret_key: '14dbd10057xu7b256e537455698c0e4e'
@@ -523,7 +521,6 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
     """
     使用讯飞的语音合成技术
     要使用本模块, 请先在 profile.xml 中启用本模块并选择合适的发音人.
-
     """
 
     SLUG = "iflytek-tts"

--- a/client/tts.py
+++ b/client/tts.py
@@ -517,8 +517,6 @@ class BaiduTTS(AbstractMp3TTSEngine):
         if tmpfile is not None:
             self.play_mp3(tmpfile)
             os.remove(tmpfile)
-            
- 
 class IFlyTekTTS(AbstractMp3TTSEngine):
     """
     使用讯飞的语音合成技术


### PR DESCRIPTION
需在profile文件中进行配置

例如：

#讯飞语音
#api_id及api_key需前往http://aiui.xfyun.cn/webApi注册获取，仅使用语音合成无需注册

#tts_engine: iflytek-tts 
#stt_engine: iflytek-stt

iflytek_yuyin:
    api_id: ''
    api_key: ''
    vid: '67100' #语音合成选项： 60120为小桃丸 67100为颖儿 60170为萌小新


#阿里云语音
#ak_id及ak_secret需前往https://data.aliyun.com/product/nls注册获取

#stt_engine: ali-stt

ali_yuyin:
    ak_id: ''
    ak_secret: ''
