### PR TITLE
增加对静态语音的缓存功能

### DIFF
--- a/client/mic.py
+++ b/client/mic.py
@@ -338,10 +338,11 @@ class Mic:
         if self.wxbot is not None:
             wechatUser(self.profile, self.wxbot, "%s: %s" %
                        (self.robot_name, phrase), "")
-        # incase calling say() method which have not implement cache feature yet.
+        # incase calling say() method which 
+        # have not implement cache feature yet.
         # the count of args should be 3.
         if self.speaker.say.func_code.co_argcount > 2:
-            self.speaker.say(phrase,cache)
+            self.speaker.say(phrase, cache)
         else:
             self.speaker.say(phrase)
         time.sleep(1)  # 避免叮当说话时误唤醒

--- a/client/mic.py
+++ b/client/mic.py
@@ -338,7 +338,7 @@ class Mic:
         if self.wxbot is not None:
             wechatUser(self.profile, self.wxbot, "%s: %s" %
                        (self.robot_name, phrase), "")
-        # incase calling say() method which 
+        # incase calling say() method which
         # have not implement cache feature yet.
         # the count of args should be 3.
         if self.speaker.say.func_code.co_argcount > 2:

--- a/client/mic.py
+++ b/client/mic.py
@@ -331,13 +331,19 @@ class Mic:
             return self.active_stt_engine.transcribe(f)
 
     def say(self, phrase,
-            OPTIONS=" -vdefault+m3 -p 40 -s 160 --stdout > say.wav"):
+            OPTIONS=" -vdefault+m3 -p 40 -s 160 --stdout > say.wav",
+            cache=False):
         self._logger.info(u"机器人说：%s" % phrase)
         self.stop_passive = True
         if self.wxbot is not None:
             wechatUser(self.profile, self.wxbot, "%s: %s" %
                        (self.robot_name, phrase), "")
-        self.speaker.say(phrase)
+        # incase calling say() method which have not implement cache feature yet.
+        # the count of args should be 3.
+        if self.speaker.say.func_code.co_argcount > 2:
+            self.speaker.say(phrase,cache)
+        else:
+            self.speaker.say(phrase)
         time.sleep(1)  # 避免叮当说话时误唤醒
         self.stop_passive = False
 

--- a/client/plugins/Hass.py
+++ b/client/plugins/Hass.py
@@ -45,11 +45,6 @@ def hass(text, mic, profile):
             entity = requests.get(url_entity, headers=headers).json()
             devices.append(entity)
     for device in devices:
-        #name = device["attributes"]["friendly_name"]
-        state = device["state"]
-        attributes = device["attributes"]
-        domain = device["entity_id"].split(".")[0]
-        if 'dingdang' in attributes.keys():
             dingdang = attributes["dingdang"]
             if isinstance(dingdang, list):
                 if text in dingdang:

--- a/client/plugins/Hass.py
+++ b/client/plugins/Hass.py
@@ -45,7 +45,7 @@ def hass(text, mic, profile):
             entity = requests.get(url_entity, headers=headers).json()
             devices.append(entity)
     for device in devices:
-        name = device["attributes"]["friendly_name"]
+        #name = device["attributes"]["friendly_name"]
         state = device["state"]
         attributes = device["attributes"]
         domain = device["entity_id"].split(".")[0]

--- a/client/plugins/Hass.py
+++ b/client/plugins/Hass.py
@@ -45,6 +45,10 @@ def hass(text, mic, profile):
             entity = requests.get(url_entity, headers=headers).json()
             devices.append(entity)
     for device in devices:
+        state = device["state"]
+        attributes = device["attributes"]
+        domain = device["entity_id"].split(".")[0]
+        if 'dingdang' in attributes.keys():
             dingdang = attributes["dingdang"]
             if isinstance(dingdang, list):
                 if text in dingdang:

--- a/client/plugins/Hass.py
+++ b/client/plugins/Hass.py
@@ -11,11 +11,11 @@ SLUG = "homeassistant"
 
 
 def handle(text, mic, profile, wxbot=None):
-    mic.say(u"开始家庭助手控制")
-    mic.say(u'请在滴一声后说明内容')
+    mic.say(u"开始家庭助手控制", cache=True)
+    mic.say(u'请在滴一声后说明内容', cache=True)
     input = mic.activeListen(MUSIC=True)
     while not input:
-        mic.say(u"请重新说")
+        mic.say(u"请重新说", cache=True)
         input = mic.activeListen(MUSIC=True)
     input = input.split(",")[0].split("，")[0]
     hass(input, mic, profile)
@@ -28,7 +28,7 @@ def hass(text, mic, profile):
     if not profile[SLUG] or 'url' not in profile[SLUG] or \
        'port' not in profile[SLUG] or \
        'password' not in profile[SLUG]:
-        mic.say(u"主人配置有误")
+        mic.say(u"主人配置有误", cache=True)
         return
     url = profile[SLUG]['url']
     port = profile[SLUG]['port']
@@ -58,10 +58,10 @@ def hass(text, mic, profile):
                         pass
                     if 'measurement' in locals().keys():
                         text = text + "状态是" + state + measurement
-                        mic.say(text)
+                        mic.say(text, cache=True)
                     else:
                         text = text + "状态是" + state
-                        mic.say(text)
+                        mic.say(text, cache=True)
                     break
             elif isinstance(dingdang, dict):
                 if text in dingdang.keys():
@@ -75,15 +75,15 @@ def hass(text, mic, profile):
                         request = requests.post(url_s, headers=headers, data=p)
                         if format(request.status_code) == "200" or \
                            format(request.status_code) == "201":
-                            mic.say(u"执行成功")
+                            mic.say(u"执行成功", cache=True)
                         else:
-                            mic.say(u"对不起,执行失败")
+                            mic.say(u"对不起,执行失败", cache=True)
                             print(format(request.status_code))
                     except Exception, e:
                         pass
                     break
     else:
-        mic.say(u"对不起,指令不存在")
+        mic.say(u"对不起,指令不存在", cache=True)
 
 
 def isValid(text):

--- a/client/tts.py
+++ b/client/tts.py
@@ -84,7 +84,7 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
     Generic class that implements the 'play' method for mp3 files
     """
     SLUG = ''
-   
+
     @classmethod
     def is_available(cls):
         return (super(AbstractMp3TTSEngine, cls).is_available() and

--- a/client/tts.py
+++ b/client/tts.py
@@ -84,7 +84,7 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
     Generic class that implements the 'play' method for mp3 files
     """
     SLUG = ''
-    
+   
     @classmethod
     def is_available(cls):
         return (super(AbstractMp3TTSEngine, cls).is_available() and
@@ -117,7 +117,7 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
                 "found speech in cache, playing...[%s]" % cache_file_path)
             self.play_mp3(cache_file_path)
         else:
-            tmpfile = self.get_speech(phrase)  
+            tmpfile = self.get_speech(phrase)
             if tmpfile is not None:
                 self.play_mp3(tmpfile)
                 if cache:

--- a/client/tts.py
+++ b/client/tts.py
@@ -83,6 +83,8 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
     """
     Generic class that implements the 'play' method for mp3 files
     """
+    SLUG = ''
+    
     @classmethod
     def is_available(cls):
         return (super(AbstractMp3TTSEngine, cls).is_available() and
@@ -106,19 +108,26 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
 
     def say(self, phrase, cache=False):
         self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
-        cache_file_path = dingdangpath.data('audio', self.SLUG + phrase + '.mp3')
+        cache_file_path = dingdangpath.data(
+            'audio',
+            self.SLUG + phrase + '.mp3'
+        )
         if cache and os.path.exists(cache_file_path):
-            self._logger.info("found speech in cache, playing...[%s]" % cache_file_path)
+            self._logger.info(
+                "found speech in cache, playing...[%s]" % cache_file_path)
             self.play_mp3(cache_file_path)
         else:
-            tmpfile = self.get_speech(phrase)
+            tmpfile = self.get_speech(phrase)  
             if tmpfile is not None:
                 self.play_mp3(tmpfile)
                 if cache:
-                    self._logger.info("not found speech in cache, caching...[%s]" % cache_file_path)
-                    os.rename(tmpfile,cache_file_path)
+                    self._logger.info(
+                        "not found speech in cache," +
+                        " caching...[%s]" % cache_file_path)
+                    os.rename(tmpfile, cache_file_path)
                 else:
                     os.remove(tmpfile)
+
 
 class SimpleMp3Player(AbstractMp3TTSEngine):
     """
@@ -539,7 +548,6 @@ class BaiduTTS(AbstractMp3TTSEngine):
             return tmpfile
 
 
-
 class IFlyTekTTS(AbstractMp3TTSEngine):
     """
     使用讯飞的语音合成技术
@@ -594,7 +602,6 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
             f.write(r.content)
             tmpfile = f.name
             return tmpfile
-
 
 
 class ALiBaBaTTS(AbstractMp3TTSEngine):

--- a/client/tts.py
+++ b/client/tts.py
@@ -100,6 +100,25 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
             if output:
                 self._logger.debug("Output was: '%s'", output)
 
+    @abstractmethod
+    def get_speech(self, phrase):
+        pass
+
+    def say(self, phrase, cache=False):
+        self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
+        cache_file_path = dingdangpath.data('audio', self.SLUG + phrase + '.mp3')
+        if cache and os.path.exists(cache_file_path):
+            self._logger.info("found speech in cache, playing...[%s]" % cache_file_path)
+            self.play_mp3(cache_file_path)
+        else:
+            tmpfile = self.get_speech(phrase)
+            if tmpfile is not None:
+                self.play_mp3(tmpfile)
+                if cache:
+                    self._logger.info("not found speech in cache, caching...[%s]" % cache_file_path)
+                    os.rename(tmpfile,cache_file_path)
+                else:
+                    os.remove(tmpfile)
 
 class SimpleMp3Player(AbstractMp3TTSEngine):
     """
@@ -519,12 +538,6 @@ class BaiduTTS(AbstractMp3TTSEngine):
             tmpfile = f.name
             return tmpfile
 
-    def say(self, phrase):
-        self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
-        tmpfile = self.get_speech(phrase)
-        if tmpfile is not None:
-            self.play_mp3(tmpfile)
-            os.remove(tmpfile)
 
 
 class IFlyTekTTS(AbstractMp3TTSEngine):
@@ -582,12 +595,6 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
             tmpfile = f.name
             return tmpfile
 
-    def say(self, phrase):
-        self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
-        tmpfile = self.get_speech(phrase)
-        if tmpfile is not None:
-            self.play_mp3(tmpfile)
-            os.remove(tmpfile)
 
 
 class ALiBaBaTTS(AbstractMp3TTSEngine):
@@ -683,13 +690,6 @@ class ALiBaBaTTS(AbstractMp3TTSEngine):
             tmpfile = f.name
             return tmpfile
 
-    def say(self, phrase):
-        self._logger.debug(u"Saying '%s' with '%s'", phrase, self.SLUG)
-        tmpfile = self.get_speech(phrase)
-        if tmpfile is not None:
-            self.play_mp3(tmpfile)
-            os.remove(tmpfile)
-
 
 class GoogleTTS(AbstractMp3TTSEngine):
     """
@@ -734,8 +734,7 @@ class GoogleTTS(AbstractMp3TTSEngine):
                  'th', 'tr', 'vi', 'cy', 'zh-yue']
         return langs
 
-    def say(self, phrase):
-        self._logger.debug("Saying '%s' with '%s'", phrase, self.SLUG)
+    def get_speech(self, phrase):
         if self.language not in self.languages:
             raise ValueError("Language '%s' not supported by '%s'",
                              self.language, self.SLUG)
@@ -743,8 +742,7 @@ class GoogleTTS(AbstractMp3TTSEngine):
         with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
             tmpfile = f.name
         tts.save(tmpfile)
-        self.play_mp3(tmpfile)
-        os.remove(tmpfile)
+        return tmpfile
 
 
 def get_default_engine_slug():

--- a/dingdang.py
+++ b/dingdang.py
@@ -87,7 +87,7 @@ class WechatBot(WXBot):
                                 return self.handle_music_mode(msg_data)
                             self.brain.query(command, self, True)
                         else:
-                            mic.say("什么？")
+                            mic.say("什么？", cache=True)
                 else:
                     # 播放语音
                     player = SimpleMp3Player()
@@ -178,7 +178,7 @@ class Dingdang(object):
             t = threading.Thread(target=self.start_wxbot)
             t.start()
 
-        self.mic.say(salutation)
+        self.mic.say(salutation, cache=True)
         conversation.handleForever()
 
 


### PR DESCRIPTION
1. 将常用的硬编码的语音(如 mic.say("开始家庭助手控制"))缓存至<dingdang path>/static/audio 中以方便下次使用,无需再次在线请求语音合成, 提高了叮当的响应速度.
2. 目前只将plugs/Hass.py应用了缓存功能. 若代码稳定后将逐步应用于其他插件.